### PR TITLE
JavaScript demos: Picovoice Worker

### DIFF
--- a/demo/javascript/react/package.json
+++ b/demo/javascript/react/package.json
@@ -47,12 +47,12 @@
       "to": "./public/scripts/pv_rhino.wasm"
     },
     {
-      "from": "../shared/rhino_worker.js",
-      "to": "./public/scripts/rhino_worker.js"
-    },
-    {
       "from": "../shared/picovoice_manager.js",
       "to": "./public/scripts/picovoice_manager.js"
+    },
+    {
+      "from": "../shared/picovoice_worker.js",
+      "to": "./public/scripts/picovoice_worker.js"
     },
     {
       "from": "../../../resources/porcupine/lib/wasm/pv_porcupine.js",
@@ -61,10 +61,6 @@
     {
       "from": "../../../resources/porcupine/lib/wasm/pv_porcupine.wasm",
       "to": "./public/scripts/pv_porcupine.wasm"
-    },
-    {
-      "from": "../../../resources/porcupine/demo/javascript/scripts/porcupine_worker.js",
-      "to": "./public/scripts/porcupine_worker.js"
     },
     {
       "from": "../../../resources/porcupine/binding/javascript/porcupine.js",

--- a/demo/javascript/react/src/picovoice/smart_lighting_demo.js
+++ b/demo/javascript/react/src/picovoice/smart_lighting_demo.js
@@ -1,8 +1,7 @@
 import { LIGHTING_CONTEXT } from "./lighting_context.js";
 import { PICOVOICE_64 } from "./picovoice_64.js";
 
-const porcupineWorkerUrl = `${process.env.PUBLIC_URL}/scripts/porcupine_worker.js`;
-const rhinoWorkerUrl = `${process.env.PUBLIC_URL}/scripts/rhino_worker.js`;
+const picovoiceWorkerUrl = `${process.env.PUBLIC_URL}/scripts/picovoice_worker.js`;
 const downsamplingWorkerUrl = `${process.env.PUBLIC_URL}/scripts/downsampling_worker.js`;
 
 class SmartLightingDemo {
@@ -30,8 +29,7 @@ class SmartLightingDemo {
       rhnCallback,
       this.errorCallback,
       initCallback,
-      porcupineWorkerUrl,
-      rhinoWorkerUrl,
+      picovoiceWorkerUrl,
       downsamplingWorkerUrl
     );
   };

--- a/demo/javascript/shared/picovoice_worker.js
+++ b/demo/javascript/shared/picovoice_worker.js
@@ -1,0 +1,117 @@
+/*
+    Copyright 2018-2020 Picovoice Inc.
+
+    You may not use this file except in compliance with the license. A copy of the license is located in the "LICENSE"
+    file accompanying this source.
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations under the License.
+*/
+
+// Callbacks are fired when the WASM has initialized. When both Porcupine and Rhino are ready, we signal the main thread that it can
+// initialize the engines and start using them, via the "pv-init" status message.
+let ppnReady = false;
+let rhnReady = false;
+
+const ppnReadyCallback = () => {
+  ppnReady = true;
+  ready();
+};
+const PorcupineOptions = { callback: ppnReadyCallback };
+
+const rhnReadyCallback = () => {
+  rhnReady = true;
+  ready();
+};
+const RhinoOptions = { callback: rhnReadyCallback };
+
+function ready() {
+  if (ppnReady && rhnReady) {
+    postMessage({ status: "pv-init" });
+  }
+}
+
+importScripts("pv_porcupine.js");
+importScripts("porcupine.js");
+
+importScripts("pv_rhino.js");
+importScripts("rhino.js");
+
+onmessage = function (e) {
+  switch (e.data.command) {
+    case "init":
+      init(e.data.keywordIDs, e.data.sensitivities, e.data.context);
+      break;
+    case "process":
+      process(e.data.inputFrame);
+      break;
+    case "pause":
+      paused = true;
+      break;
+    case "resume":
+      paused = false;
+      break;
+    case "release":
+      release();
+      break;
+  }
+};
+
+let isWakeWordDetected;
+let paused;
+
+let keywords;
+let sensitivities;
+let context;
+
+let porcupine = null;
+let rhino = null;
+
+function init(_keywordIDs, _sensitivities, _context) {
+  isWakeWordDetected = false;
+  paused = false;
+
+  let keywordIDArray = Object.values(_keywordIDs);
+  keywords = Object.keys(_keywordIDs);
+  sensitivities = _sensitivities;
+  porcupine = Porcupine.create(keywordIDArray, _sensitivities);
+
+  context = _context;
+  rhino = Rhino.create(context);
+}
+
+function process(inputFrame) {
+  if (porcupine !== null && rhino !== null && !paused) {
+    if (!isWakeWordDetected) {
+      let keywordIndex = porcupine.process(inputFrame);
+      if (keywordIndex !== -1) {
+        postMessage({
+          keyword: keywords[keywordIndex],
+        });
+        isWakeWordDetected = true;
+      }
+    } else {
+      let result = rhino.process(inputFrame);
+      if ("isUnderstood" in result) {
+        postMessage(result);
+        isWakeWordDetected = false;
+      }
+    }
+  }
+}
+
+function release() {
+  if (porcupine !== null) {
+    porcupine.release();
+  }
+
+  porcupine = null;
+
+  if (rhino != null) {
+    rhino.release();
+  }
+
+  rhino = null;
+  close();
+}

--- a/demo/javascript/vanilla/.gitignore
+++ b/demo/javascript/vanilla/.gitignore
@@ -1,11 +1,10 @@
 node_modules
 package-lock.json
 porcupine.js
-porcupine_worker.js
+picovoice_worker.js
 pv_porcupine.js
 pv_porcupine.wasm
 pv_rhino.js
 pv_rhino.wasm
 rhino.js
-rhino_worker.js
 picovoice_manager.js

--- a/demo/javascript/vanilla/index.html
+++ b/demo/javascript/vanilla/index.html
@@ -1357,8 +1357,7 @@
           inferenceCallback,
           errorCallback,
           initCallback,
-          "/porcupine_worker.js",
-          "/rhino_worker.js",
+          "/picovoice_worker.js",
           "/node_modules/@picovoice/web-voice-processor/src/downsampling_worker.js"
         );
 

--- a/demo/javascript/vanilla/package.json
+++ b/demo/javascript/vanilla/package.json
@@ -33,8 +33,8 @@
       "to": "pv_rhino.wasm"
     },
     {
-      "from": "../shared/rhino_worker.js",
-      "to": "rhino_worker.js"
+      "from": "../shared/picovoice_worker.js",
+      "to": "picovoice_worker.js"
     },
     {
       "from": "../shared/picovoice_manager.js",
@@ -47,10 +47,6 @@
     {
       "from": "../../../resources/porcupine/lib/wasm/pv_porcupine.wasm",
       "to": "pv_porcupine.wasm"
-    },
-    {
-      "from": "../../../resources/porcupine/demo/javascript/scripts/porcupine_worker.js",
-      "to": "porcupine_worker.js"
     },
     {
       "from": "../../../resources/porcupine/binding/javascript/porcupine.js",


### PR DESCRIPTION
Refactor the JavaScript demos to use a single unified "Picovoice" worker instead of Porcupine and Rhino workers. Move some of the logic for initialization and switching engines into the new worker to simplify the PicovoiceManager.