### PR TITLE
Make Python unittests exhibit correct test behavior

### DIFF
--- a/sdk/python/test_picovoice.py
+++ b/sdk/python/test_picovoice.py
@@ -19,6 +19,7 @@ import pvporcupine
 import soundfile
 from picovoice import Picovoice
 
+
 class PicovoiceTestCase(unittest.TestCase):
     @staticmethod
     def _context_path():


### PR DESCRIPTION
Previous python tests were not exhibiting the correct behaviour. 

The intention is for the test to be run twice in order to see if `Picovoice` returns to it's wake word detection state, however the previous use of `setUp` and `tearDown` meant that the `Picovoice` object was getting made and destroyed for EACH test, therefore making the use of two tests redundant.

By switching to `setUpClass` and `tearDownClass`, the creation/deletion of the `Picovoice` object is now done once for the entire suite, so we can actually test if the object is returning to wake word detection.