### PR TITLE
update current reference to porcupine and rhino callbacks (#366)

### DIFF
--- a/sdk/react/src/use_picovoice.ts
+++ b/sdk/react/src/use_picovoice.ts
@@ -103,6 +103,9 @@ export function usePicovoice(
   /** Refresh the keyword and inference callbacks
    * when they change (avoid stale closure) */
   useEffect(() => {
+    porcupineCallback.current = keywordCallback;
+    rhinoCallback.current = inferenceCallback;
+
     if (picovoiceWorker !== null) {
       picovoiceWorker.onmessage = (
         message: MessageEvent<PicovoiceWorkerResponse>
@@ -124,7 +127,7 @@ export function usePicovoice(
         }
       };
     }
-  }, [porcupineCallback, rhinoCallback]);
+  }, [keywordCallback, inferenceCallback, picovoiceWorker]);
 
   useEffect(() => {
     if (


### PR DESCRIPTION
In the useEffect hook, update the porcupine and rhino callbacks when the
value passed to the hook changes, and change the dependency array to contain
the callbacks passed as arguments.

Previously, the useRef objects were passed as dependencies and never updated,
so the underlying callback never changes.